### PR TITLE
Unlock vault only when it's needed

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 import subprocess
 
 class BitwardenCommandException(Exception):
@@ -8,6 +9,11 @@ def get_secret_from_bitwarden(id):
     return command_wrapper(command=f"get item {id}")
 
 def unlock_bw(logger):
+    status_output = command_wrapper("status")
+    status = json.loads(status_output)['status']
+    if status == 'unlocked':
+        logger.info("Already unlocked")
+        return
     token_output = command_wrapper("unlock --passwordenv BW_PASSWORD")
     tokens = token_output.split('"')[1::2]
     os.environ["BW_SESSION"] = tokens[1]


### PR DESCRIPTION
This PR remove this error message:

```
[2023-01-18 20:45:46,918] kopf.objects         [ERROR   ] [system/pihole.home.ttb.lt] Timer 'update_managed_secret' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/env/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 279, in execute_handler_once
    result = await invoke_handler(
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/env/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 374, in invoke_handler
    result = await invocation.invoke(
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/env/lib/python3.10/site-packages/kopf/_core/actions/invocation.py", line 139, in invoke
    await asyncio.shield(future)  # slightly expensive: creates tasks
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/src/kv.py", line 72, in update_managed_secret
    secret_json_object = json.loads(get_secret_from_bitwarden(id))
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/src/utils/utils.py", line 8, in get_secret_from_bitwarden
    return command_wrapper(command=f"get item {id}")
  File "/home/tcohen/perso/gits/github.com/Lerentis/bitwarden-crd-operator/src/utils/utils.py", line 26, in command_wrapper
    if err:
utils.utils.BitwardenCommandException: b'mac failed.\n? Master password: [input is hidden] \x1b[37D\x1b[37C'
```