### PR TITLE
Switch to JSON mode of cli

### DIFF
--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -95,7 +95,7 @@ annotations:
   artifacthub.io/operator: "true"  
   artifacthub.io/changes: |
     - kind: changed
-      description: "Default image registry to ghcr.io and no longer docker hub. docker hub images will continue to be published"
+      description: "Use JSON output mode (--response) of Bitwarden CLI."
   artifacthub.io/images: |
     - name: bitwarden-crd-operator
       image: ghcr.io/lerentis/bitwarden-crd-operator:0.5.4

--- a/src/bitwardenCrdOperator.py
+++ b/src/bitwardenCrdOperator.py
@@ -9,12 +9,12 @@ from utils.utils import command_wrapper, unlock_bw
 def bitwarden_signin(logger, **kwargs):
     if 'BW_HOST' in os.environ:
         try:
-            command_wrapper(f"config server {os.getenv('BW_HOST')}")
+            command_wrapper(logger, f"config server {os.getenv('BW_HOST')}")
         except BaseException:
-            logger.warn("Revieved none zero exit code from server config")
+            logger.warn("Received non-zero exit code from server config")
             logger.warn("This is expected from startup")
             pass
     else:
         logger.info("BW_HOST not set. Assuming SaaS installation")
-    command_wrapper("login --apikey")
+    command_wrapper(logger, "login --apikey")
     unlock_bw(logger)

--- a/src/dockerlogin.py
+++ b/src/dockerlogin.py
@@ -60,7 +60,7 @@ def create_managed_registry_secret(spec, name, namespace, logger, **kwargs):
     secret = create_dockerlogin(
         logger,
         secret,
-        secret_json_object,
+        secret_json_object["data"],
         username_ref,
         password_ref,
         registry)
@@ -132,7 +132,7 @@ def update_managed_registry_secret(
     secret = create_dockerlogin(
         logger,
         secret,
-        secret_json_object,
+        secret_json_object["data"],
         username_ref,
         password_ref,
         registry)

--- a/src/dockerlogin.py
+++ b/src/dockerlogin.py
@@ -46,7 +46,7 @@ def create_managed_registry_secret(spec, name, namespace, logger, **kwargs):
 
     unlock_bw(logger)
     logger.info(f"Locking up secret with ID: {id}")
-    secret_json_object = json.loads(get_secret_from_bitwarden(id))
+    secret_json_object = get_secret_from_bitwarden(logger, id)
 
     api = kubernetes.client.CoreV1Api()
 
@@ -118,7 +118,7 @@ def update_managed_registry_secret(
 
     unlock_bw(logger)
     logger.info(f"Locking up secret with ID: {id}")
-    secret_json_object = json.loads(get_secret_from_bitwarden(id))
+    secret_json_object = get_secret_from_bitwarden(logger, id)
 
     api = kubernetes.client.CoreV1Api()
 

--- a/src/kv.py
+++ b/src/kv.py
@@ -45,7 +45,7 @@ def create_managed_secret(spec, name, namespace, logger, body, **kwargs):
 
     unlock_bw(logger)
     logger.info(f"Locking up secret with ID: {id}")
-    secret_json_object = json.loads(get_secret_from_bitwarden(id))
+    secret_json_object = get_secret_from_bitwarden(logger, id)
 
     api = kubernetes.client.CoreV1Api()
 
@@ -106,7 +106,7 @@ def update_managed_secret(
 
     unlock_bw(logger)
     logger.info(f"Locking up secret with ID: {id}")
-    secret_json_object = json.loads(get_secret_from_bitwarden(id))
+    secret_json_object = get_secret_from_bitwarden(logger, id)
 
     api = kubernetes.client.CoreV1Api()
 

--- a/src/lookups/bitwarden_lookup.py
+++ b/src/lookups/bitwarden_lookup.py
@@ -4,7 +4,7 @@ from utils.utils import get_secret_from_bitwarden, parse_fields_scope, parse_log
 
 
 def bitwarden_lookup(id, scope, field):
-    _secret_json = json.loads(get_secret_from_bitwarden(id))
+    _secret_json = get_secret_from_bitwarden(None, id)
     if scope == "login":
         return parse_login_scope(_secret_json, field)
     if scope == "fields":

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -7,44 +7,47 @@ class BitwardenCommandException(Exception):
     pass
 
 
-def get_secret_from_bitwarden(id):
-    return command_wrapper(command=f"get item {id}")
+def get_secret_from_bitwarden(logger, id):
+    return command_wrapper(logger, command=f"get item {id}")
 
 
 def unlock_bw(logger):
-    status_output = command_wrapper("status")
-    status = json.loads(status_output)['status']
+    status_output = command_wrapper(logger, "status", False)
+    status = status_output['data']['template']['status']
     if status == 'unlocked':
         logger.info("Already unlocked")
         return
-    token_output = command_wrapper("unlock --passwordenv BW_PASSWORD")
-    tokens = token_output.split('"')[1::2]
-    os.environ["BW_SESSION"] = tokens[1]
+    token_output = command_wrapper(logger, "unlock --passwordenv BW_PASSWORD")
+    os.environ["BW_SESSION"] = token_output["data"]["raw"]
     logger.info("Signin successful. Session exported")
 
 
-def command_wrapper(command):
+def command_wrapper(logger, command, use_success: bool = True):
     system_env = dict(os.environ)
     sp = subprocess.Popen(
-        [f"bw {command}"],
+        [f"bw --response {command}"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
         shell=True,
         env=system_env)
     out, err = sp.communicate()
-    if err:
-        raise BitwardenCommandException(err)
-    return out.decode(encoding='UTF-8')
+    resp = json.loads(out.decode(encoding='UTF-8'))
+    if os.environ["DEBUG"] != None:
+        logger.info(resp)
+    if resp["success"] != None and (not use_success or (use_success and resp["success"] == True)):
+        return resp
+    logger.warn(resp)
+    return None
 
 
 def parse_login_scope(secret_json, key):
-    return secret_json["login"][key]
+    return secret_json["data"]["login"][key]
 
 
 def parse_fields_scope(secret_json, key):
     if "fields" not in secret_json:
         return None
-    for entry in secret_json["fields"]:
+    for entry in secret_json["data"]["fields"]:
         if entry['name'] == key:
             return entry['value']

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -33,7 +33,7 @@ def command_wrapper(logger, command, use_success: bool = True):
         env=system_env)
     out, err = sp.communicate()
     resp = json.loads(out.decode(encoding='UTF-8'))
-    if os.environ["DEBUG"] != None:
+    if "DEBUG" in system_env:
         logger.info(resp)
     if resp["success"] != None and (not use_success or (use_success and resp["success"] == True)):
         return resp


### PR DESCRIPTION
Hi,

First of all, thank you for this project - definitely a big help for us!

I had to change a few things to actually get it to even start, otherwise it would crash while unlocking. Mostly because the CLI is apparently writing success messages to stderr.

We are using the Bitwarden SaaS offering, so I'm not sure if the BW CLI behaves differently in that case.

Summary:
- Using `--response` switch of the CLI so that it always return JSON responses
- Ignoring stderr, as the JSON message now provides `success`
- Pass around logger to help with debugging 

Let me know what you think.