### PR TITLE
Load attachments from BW item

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ type: dockerconfigjson
 
 ## BitwardenTemplate
 
-One of the more freely defined types that can be used with this operator you can just pass a whole template:
+One of the more freely defined types that can be used with this operator you can just pass a whole template. Also the lookup function `bitwarden_lookup` is available to reference parts of the secret:
 
 ```yaml
 ---
@@ -145,11 +145,11 @@ spec:
     ---
     api:
       enabled: True
-      key: {{ bitwarden_lookup("A Secret ID from bitwarden", "login or fields", "name of a field in bitwarden") }}
+      key: {{ bitwarden_lookup("A Secret ID from bitwarden", "login or fields or attachment", "name of a field in bitwarden") }}
       allowCrossOrigin: false
       apps:
         "some.app.identifier:some_version":
-          pubkey: {{ bitwarden_lookup("A Secret ID from bitwarden", "login or fields", "name of a field in bitwarden") }}
+          pubkey: {{ bitwarden_lookup("A Secret ID from bitwarden", "login or fields or attachment", "name of a field in bitwarden") }}
           enabled: true
 ```
 
@@ -169,7 +169,15 @@ metadata:
 type: Opaque
 ```
 
-please note that the rendering engine for this template is jinja2, with an addition of a custom `bitwarden_lookup` function, so there are more possibilities to inject here.
+The signature of `bitwarden_lookup` is `(item_id, scope, field)`:
+- `item_id`: The item ID of the secret in Bitwarden
+- `scope`: one of `login`, `fields` or `attachment`
+- `field`:
+  - when `scope` is `login`: either `username` or `password`
+  - when `scope` is `fields`: the name of a custom field
+  - when `scope` is `attachment`: the filename of a file attached to the item
+
+Please note that the rendering engine for this template is jinja2, with an addition of a custom `bitwarden_lookup` function, so there are more possibilities to inject here.
 
 ## Configurations parameters
 

--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -4,9 +4,9 @@ description: Deploy the Bitwarden CRD Operator
 
 type: application
 
-version: "v0.9.0"
+version: "v0.10.0"
 
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 
 keywords:
   - operator
@@ -89,18 +89,14 @@ annotations:
             allowCrossOrigin: false
             apps:
               "some.app.identifier:some_version":
-                pubkey: {{ bitwarden_lookup("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "fields", "public_key") }}
+                pubkey: {{ bitwarden_lookup("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "attachment", "public_key") }}
                 enabled: true
   artifacthub.io/license: MIT
   artifacthub.io/operator: "true"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Unified scheduled none crd related operations (bw sync and login)"
     - kind: added
-      description: "Added relogin interval which can be finetuned with env `BW_RELOGIN_INTERVAL`. defaults to 3600 seconds"
-    - kind: chanced
-      description: "Updated python to 3.11.6-r0"
+      description: "Added attachment lookup to bitwarden_lookup in BitwardenTemplate CRD"
   artifacthub.io/images: |
     - name: bitwarden-crd-operator
-      image: ghcr.io/lerentis/bitwarden-crd-operator:0.8.0
+      image: ghcr.io/lerentis/bitwarden-crd-operator:0.9.0

--- a/src/lookups/bitwarden_lookup.py
+++ b/src/lookups/bitwarden_lookup.py
@@ -1,13 +1,16 @@
-import json
-
 from utils.utils import get_secret_from_bitwarden, get_attachment, parse_fields_scope, parse_login_scope
 
 
-def bitwarden_lookup(id, scope, field):
-    if scope == "attachment":
-        return get_attachment(None, id, field)
-    _secret_json = get_secret_from_bitwarden(None, id)
-    if scope == "login":
-        return parse_login_scope(_secret_json, field)
-    if scope == "fields":
-        return parse_fields_scope(_secret_json, field)
+class BitwardenLookupHandler:
+
+    def __init__(self, logger) -> None:
+        self.logger = logger
+
+    def bitwarden_lookup(self, id, scope, field):
+        if scope == "attachment":
+            return get_attachment(self.logger, id, field)
+        _secret_json = get_secret_from_bitwarden(self.logger, id)
+        if scope == "login":
+            return parse_login_scope(_secret_json, field)
+        if scope == "fields":
+            return parse_fields_scope(_secret_json, field)

--- a/src/lookups/bitwarden_lookup.py
+++ b/src/lookups/bitwarden_lookup.py
@@ -1,9 +1,11 @@
 import json
 
-from utils.utils import get_secret_from_bitwarden, parse_fields_scope, parse_login_scope
+from utils.utils import get_secret_from_bitwarden, get_attachment, parse_fields_scope, parse_login_scope
 
 
 def bitwarden_lookup(id, scope, field):
+    if scope == "attachment":
+        return get_attachment(None, id, field)
     _secret_json = get_secret_from_bitwarden(None, id)
     if scope == "login":
         return parse_login_scope(_secret_json, field)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -40,7 +40,7 @@ def sync_bw(logger, force=False):
 
 
 def get_attachment(logger, id, name):
-    return command_wrapper(logger, command=f"get attachment {name} {id}", raw=True)
+    return command_wrapper(logger, command=f"get attachment {name} --itemid {id}", raw=True)
 
 
 def unlock_bw(logger):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -39,6 +39,10 @@ def sync_bw(logger, force=False):
         logger.info(f"Sync successful {status_output}")
 
 
+def get_attachment(logger, id, name):
+    return command_wrapper(logger, command=f"get attachment {name} {id}", raw=True)
+
+
 def unlock_bw(logger):
     status_output = command_wrapper(logger, "status", False)
     status = status_output['data']['template']['status']
@@ -50,17 +54,22 @@ def unlock_bw(logger):
     logger.info("Signin successful. Session exported")
 
 
-def command_wrapper(logger, command, use_success: bool = True):
+def command_wrapper(logger, command, use_success: bool = True, raw: bool = False):
     system_env = dict(os.environ)
+    response_flag = "--raw" if raw else "--response"
     sp = subprocess.Popen(
-        [f"bw --response {command}"],
+        [f"bw {response_flag} {command}"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
         shell=True,
         env=system_env)
     out, err = sp.communicate()
-
+    if err:
+        logger.warn(err)
+        return None
+    if raw:
+        return out.decode(encoding='UTF-8')
     if "DEBUG" in system_env:
         logger.info(out.decode(encoding='UTF-8'))
     resp = json.loads(out.decode(encoding='UTF-8'))


### PR DESCRIPTION
This introduces the possibility to load attachments from Bitwarden items in the `BitwardenTemplate` CRD. E.g.

```yaml
---
apiVersion: "lerentis.uploadfilter24.eu/v1beta4"
kind: BitwardenTemplate
metadata:
  name: bw-attachment-test
  namespace: apps
spec:
  filename: private-key
  name: bw-attachment-test
  namespace: default
  template: |
    {{ bitwarden_lookup("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "attachment", "private-key") }}
```

Before I go ahead an update documentation and changelog, I'd like to have some feedback whether this is the right direction.

Also I had some issues branching off from the current main HEAD, with BW failing to start in a very early stage (I assume there were some breaking changes between BW CLI 2023.1.0 and 2023.7.0). Therefore this branch is based off of the previous release.