### PR TITLE
Allow lookup of secrets by name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bitwarden CRD Operator is a kubernetes Operator based on [kopf](https://github.c
   <img src="logo.png" alt="Bitwarden CRD Operator Logo" width="200"/>
 </p>
 
-> DISCLAIMER:  
+> DISCLAIMER:
 > This project is still very work in progress :)
 
 
@@ -45,7 +45,7 @@ After that it is a basic helm deployment:
 
 ```bash
 helm repo add bitwarden-operator https://lerentis.github.io/bitwarden-crd-operator
-helm repo update 
+helm repo update
 kubectl create namespace bw-operator
 helm upgrade --install --namespace bw-operator -f values.yaml bw-operator bitwarden-operator/bitwarden-crd-operator
 ```
@@ -56,7 +56,7 @@ And you are set to create your first secret using this operator. For that you ne
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenSecret
 metadata:
   name: name-of-your-management-object
@@ -64,12 +64,12 @@ spec:
   content:
     - element:
         secretName: nameOfTheFieldInBitwarden # for example username
-        secretRef: nameOfTheKeyInTheSecretToBeCreated 
-        secretScope: login # for custom entries on bitwarden use 'fields' 
+        secretRef: nameOfTheKeyInTheSecretToBeCreated
+        secretScope: login # for custom entries on bitwarden use 'fields'
     - element:
         secretName: nameOfAnotherFieldInBitwarden # for example password
-        secretRef: nameOfAnotherKeyInTheSecretToBeCreated 
-        secretScope: login # for custom entries on bitwarden use 'fields' 
+        secretRef: nameOfAnotherKeyInTheSecretToBeCreated
+        secretScope: login # for custom entries on bitwarden use 'fields'
   id: "A Secret ID from bitwarden"
   name: "Name of the secret to be created"
   namespace: "Namespace of the secret to be created"
@@ -102,7 +102,7 @@ For managing registry credentials, or pull secrets, you can create another kind 
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: RegistryCredential
 metadata:
   name: name-of-your-management-object
@@ -141,7 +141,7 @@ One of the more freely defined types that can be used with this operator you can
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenTemplate
 metadata:
   name: name-of-your-management-object

--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -65,6 +65,24 @@ annotations:
         labels:
           key: value
     - apiVersion: lerentis.uploadfilter24.eu/v1beta5
+      kind: BitwardenSecret
+      metadata:
+        name: test
+      spec:
+        content:
+          - element:
+              secretName: username
+              secretRef: nameofUser
+          - element:
+              secretName: password
+              secretRef: passwordOfUser
+        itemName: "SecretName"
+        collectionPath: "Some/App/Identifier/Path"
+        name: "test-secret-from-item-name"
+        namespace: "default"
+        labels:
+          key: value
+    - apiVersion: lerentis.uploadfilter24.eu/v1beta5
       kind: RegistryCredential
       metadata:
         name: test
@@ -97,6 +115,9 @@ annotations:
               "some.app.identifier:some_version":
                 pubkey: {{ bitwarden_lookup("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "attachment", "public_key") }}
                 enabled: true
+                username: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "login", "username") }}
+                specialField: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "fields", "specialField") }}
+                pvtkey: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "attachment", "private_key") }}
   artifacthub.io/license: MIT
   artifacthub.io/operator: "true"
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -4,9 +4,9 @@ description: Deploy the Bitwarden CRD Operator
 
 type: application
 
-version: "v0.11.3"
+version: "v0.12.0"
 
-appVersion: "0.10.3"
+appVersion: "0.11.0"
 
 keywords:
   - operator
@@ -32,22 +32,22 @@ annotations:
       url: https://github.com/Lerentis/bitwarden-crd-operator
   artifacthub.io/crds: |
     - kind: BitwardenSecret
-      version: v1beta5
+      version: v1beta6
       name: bitwarden-secret
       displayName: Bitwarden Secret
       description: Management Object to create secrets from bitwarden
     - kind: RegistryCredential
-      version: v1beta5
+      version: v1beta6
       name: registry-credential
       displayName: Regestry Credentials
       description: Management Object to create regestry secrets from bitwarden
     - kind: BitwardenTemplate
-      version: v1beta5
+      version: v1beta6
       name: bitwarden-template
       displayName: Bitwarden Template
       description: Management Object to create secrets from a jinja template with a bitwarden lookup
   artifacthub.io/crdsExamples: |
-    - apiVersion: lerentis.uploadfilter24.eu/v1beta5
+    - apiVersion: lerentis.uploadfilter24.eu/v1beta6
       kind: BitwardenSecret
       metadata:
         name: test
@@ -64,7 +64,7 @@ annotations:
         namespace: "default"
         labels:
           key: value
-    - apiVersion: lerentis.uploadfilter24.eu/v1beta5
+    - apiVersion: lerentis.uploadfilter24.eu/v1beta6
       kind: BitwardenSecret
       metadata:
         name: test
@@ -82,7 +82,7 @@ annotations:
         namespace: "default"
         labels:
           key: value
-    - apiVersion: lerentis.uploadfilter24.eu/v1beta5
+    - apiVersion: lerentis.uploadfilter24.eu/v1beta6
       kind: RegistryCredential
       metadata:
         name: test
@@ -95,7 +95,7 @@ annotations:
         namespace: "default"
         labels:
           key: value
-    - apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+    - apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
       kind: BitwardenTemplate
       metadata:
         name: test
@@ -122,12 +122,14 @@ annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: added
+      description: "Allow secret lookup by name and collection path"
     - kind: changed
-      description: "Update python to 3.11.8-r0"
+      description: "Deprecated v1beta4 and introduced v1beta6"
+    - kind: added
+      description: "Added owner_references block to generated secret metadata"
     - kind: changed
-      description: "Update Node to 20.11.1-r0"
-    - kind: changed
-      description: "Unified bw cli installation methode"
+      description: "Refactor some code to remove code duplication."
   artifacthub.io/images: |
     - name: bitwarden-crd-operator
-      image: ghcr.io/lerentis/bitwarden-crd-operator:0.10.3
+      image: ghcr.io/lerentis/bitwarden-crd-operator:0.11.0

--- a/charts/bitwarden-crd-operator/README.md
+++ b/charts/bitwarden-crd-operator/README.md
@@ -8,7 +8,7 @@ Bitwarden CRD Operator is a kubernetes Operator based on [kopf](https://github.c
   <img src="https://github.com/Lerentis/bitwarden-crd-operator/blob/main/logo.png?raw=true" alt="Bitwarden CRD Operator Logo" width="200"/>
 </p>
 
-> DISCLAIMER:  
+> DISCLAIMER:
 > This project is still very work in progress :)
 
 
@@ -45,7 +45,7 @@ After that it is a basic helm deployment:
 
 ```bash
 helm repo add bitwarden-operator https://lerentis.github.io/bitwarden-crd-operator
-helm repo update 
+helm repo update
 kubectl create namespace bw-operator
 helm upgrade --install --namespace bw-operator -f values.yaml bw-operator bitwarden-operator/bitwarden-crd-operator
 ```
@@ -56,7 +56,7 @@ And you are set to create your first secret using this operator. For that you ne
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta4"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenSecret
 metadata:
   name: name-of-your-management-object
@@ -64,12 +64,12 @@ spec:
   content:
     - element:
         secretName: nameOfTheFieldInBitwarden # for example username
-        secretRef: nameOfTheKeyInTheSecretToBeCreated 
-        secretScope: login # for custom entries on bitwarden use 'fields' 
+        secretRef: nameOfTheKeyInTheSecretToBeCreated
+        secretScope: login # for custom entries on bitwarden use 'fields'
     - element:
         secretName: nameOfAnotherFieldInBitwarden # for example password
-        secretRef: nameOfAnotherKeyInTheSecretToBeCreated 
-        secretScope: login # for custom entries on bitwarden use 'fields' 
+        secretRef: nameOfAnotherKeyInTheSecretToBeCreated
+        secretScope: login # for custom entries on bitwarden use 'fields'
   id: "A Secret ID from bitwarden"
   name: "Name of the secret to be created"
   namespace: "Namespace of the secret to be created"
@@ -98,7 +98,7 @@ For managing registry credentials, or pull secrets, you can create another kind 
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta4"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: RegistryCredential
 metadata:
   name: name-of-your-management-object
@@ -133,7 +133,7 @@ One of the more freely defined types that can be used with this operator you can
 
 ```yaml
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta4"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenTemplate
 metadata:
   name: name-of-your-management-object

--- a/charts/bitwarden-crd-operator/crds/bitwarden-secrets.yaml
+++ b/charts/bitwarden-crd-operator/crds/bitwarden-secrets.yaml
@@ -13,7 +13,7 @@ spec:
     shortNames:
       - bws
   versions:
-    - name: v1beta4
+    - name: v1beta5
       served: true
       storage: false
       deprecated: true
@@ -42,15 +42,22 @@ spec:
                           - secretName
                 id:
                   type: string
+                itemName:
+                  type: string
+                collectionPath:
+                  type: string
                 namespace:
                   type: string
                 name:
                   type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               required:
-                - id
                 - namespace
                 - name
-    - name: v1beta5
+                - id
+    - name: v1beta6
       served: true
       storage: true
       schema:

--- a/charts/bitwarden-crd-operator/crds/bitwarden-secrets.yaml
+++ b/charts/bitwarden-crd-operator/crds/bitwarden-secrets.yaml
@@ -78,6 +78,10 @@ spec:
                           - secretName
                 id:
                   type: string
+                itemName:
+                  type: string
+                collectionPath:
+                  type: string
                 namespace:
                   type: string
                 name:
@@ -86,6 +90,11 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
               required:
-                - id
                 - namespace
                 - name
+              oneOf:
+              - required:
+                  - id
+              - required:
+                  - itemName
+                  - collectionPath

--- a/charts/bitwarden-crd-operator/crds/bitwarden-templates.yaml
+++ b/charts/bitwarden-crd-operator/crds/bitwarden-templates.yaml
@@ -13,7 +13,7 @@ spec:
     shortNames:
       - bwt
   versions:
-    - name: v1beta4
+    - name: v1beta5
       served: true
       storage: false
       deprecated: true
@@ -32,12 +32,15 @@ spec:
                   type: string
                 name:
                   type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
               required:
                 - filename
                 - template
                 - namespace
                 - name
-    - name: v1beta5
+    - name: v1beta6
       served: true
       storage: true
       schema:

--- a/charts/bitwarden-crd-operator/crds/registry-credentials.yaml
+++ b/charts/bitwarden-crd-operator/crds/registry-credentials.yaml
@@ -13,39 +13,10 @@ spec:
     shortNames:
       - rgc
   versions:
-    - name: v1beta4
+    - name: v1beta5
       served: true
       storage: false
       deprecated: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            spec:
-              type: object
-              properties:
-                usernameRef:
-                  type: string
-                passwordRef:
-                  type: string
-                registry:
-                  type: string
-                id:
-                  type: string
-                namespace:
-                  type: string
-                name:
-                  type: string
-              required:
-                - id
-                - namespace
-                - name
-                - usernameRef
-                - passwordRef
-                - registry
-    - name: v1beta5
-      served: true
-      storage: true
       schema:
         openAPIV3Schema:
           type: object
@@ -75,3 +46,44 @@ spec:
                 - usernameRef
                 - passwordRef
                 - registry
+    - name: v1beta6
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                usernameRef:
+                  type: string
+                passwordRef:
+                  type: string
+                registry:
+                  type: string
+                id:
+                  type: string
+                itemName:
+                  type: string
+                collectionPath:
+                  type: string
+                namespace:
+                  type: string
+                name:
+                  type: string
+                labels:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - namespace
+                - name
+                - usernameRef
+                - passwordRef
+                - registry
+              oneOf:
+              - required:
+                  - id
+              - required:
+                  - itemName
+                  - collectionPath

--- a/example.yaml
+++ b/example.yaml
@@ -7,11 +7,11 @@ spec:
   content:
     - element:
         secretName: username
-        secretRef: nameofUser 
+        secretRef: nameofUser
         secretScope: login
     - element:
         secretName: password
-        secretRef: passwordOfUser 
+        secretRef: passwordOfUser
         secretScope: login
   id: "88781348-c81c-4367-9801-550360c21295"
   name: "test-secret"
@@ -28,8 +28,22 @@ spec:
   content:
     - element:
         secretName: public_key
-        secretRef: pubKey 
+        secretRef: pubKey
         secretScope: fields
   id: "466fc4b0-ffca-4444-8d88-b59d4de3d928"
   name: "test-scope"
+  namespace: "default"
+---
+apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+kind: BitwardenSecret
+metadata:
+  name: test-lookup-by-name
+spec:
+  content:
+    - element:
+        secretName: public_key
+        secretRef: pubKey
+        secretScope: fields
+  collectionPath: "Some/App/Identifier/Path"
+  itemName: "test-secret-lookup-by-name"
   namespace: "default"

--- a/example.yaml
+++ b/example.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenSecret
 metadata:
   name: test
@@ -20,7 +20,7 @@ spec:
     key: value
     app: example-app
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenSecret
 metadata:
   name: test-scope
@@ -34,7 +34,7 @@ spec:
   name: "test-scope"
   namespace: "default"
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenSecret
 metadata:
   name: test-lookup-by-name

--- a/example.yaml
+++ b/example.yaml
@@ -45,5 +45,6 @@ spec:
         secretRef: pubKey
         secretScope: fields
   collectionPath: "Some/App/Identifier/Path"
+  name: "bitwarden-secret-name"
   itemName: "test-secret-lookup-by-name"
   namespace: "default"

--- a/example_dockerlogin.yaml
+++ b/example_dockerlogin.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: RegistryCredential
 metadata:
   name: test

--- a/example_template.yaml
+++ b/example_template.yaml
@@ -20,3 +20,6 @@ spec:
         "some.app.identifier:some_version":
           pubkey: {{ bitwarden_lookup("466fc4b0-ffca-4444-8d88-b59d4de3d928", "fields", "public_key") }}
           enabled: true
+          username: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "login", "username") }}
+          specialField: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "fields", "specialField") }}
+          pvtkey: {{ bitwarden_lookup_with_name("Some/App/Identifier/Path", "SecretName", "attachment", "private_key") }}

--- a/example_template.yaml
+++ b/example_template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: "lerentis.uploadfilter24.eu/v1beta5"
+apiVersion: "lerentis.uploadfilter24.eu/v1beta6"
 kind: BitwardenTemplate
 metadata:
   name: test

--- a/src/bitwardenCrdOperator.py
+++ b/src/bitwardenCrdOperator.py
@@ -19,6 +19,7 @@ def bitwarden_signin(logger, **kwargs):
         logger.info("BW_HOST not set. Assuming SaaS installation")
     command_wrapper(logger, "login --apikey")
     unlock_bw(logger)
+    sync_bw(logger)
 
 def run_continuously(interval=30):
     cease_continuous_run = threading.Event()

--- a/src/lookups/bitwarden_lookup.py
+++ b/src/lookups/bitwarden_lookup.py
@@ -1,5 +1,6 @@
-from utils.utils import get_secret_from_bitwarden, get_collection_secret_from_bitwarden, \
-                        get_attachment, parse_fields_scope, parse_login_scope
+from utils.utils import get_secret_from_bitwarden, get_secret_with_id_from_bitwarden, \
+                        get_collection_secret_from_bitwarden, get_attachment, \
+                        parse_fields_scope, parse_login_scope
 
 
 class BitwardenLookupHandler:

--- a/src/lookups/bitwarden_lookup.py
+++ b/src/lookups/bitwarden_lookup.py
@@ -1,4 +1,5 @@
-from utils.utils import get_secret_from_bitwarden, get_attachment, parse_fields_scope, parse_login_scope
+from utils.utils import get_secret_from_bitwarden, get_collection_secret_from_bitwarden, \
+                        get_attachment, parse_fields_scope, parse_login_scope
 
 
 class BitwardenLookupHandler:
@@ -9,7 +10,17 @@ class BitwardenLookupHandler:
     def bitwarden_lookup(self, id, scope, field):
         if scope == "attachment":
             return get_attachment(self.logger, id, field)
-        _secret_json = get_secret_from_bitwarden(self.logger, id)
+        _secret_json = get_secret_with_id_from_bitwarden(self.logger, id)
+        if scope == "login":
+            return parse_login_scope(_secret_json, field)
+        if scope == "fields":
+            return parse_fields_scope(_secret_json, field)
+
+    def bitwarden_lookup_with_name(self, collection_path, item_name, scope, field):
+        _secret_json = get_collection_secret_from_bitwarden(self.logger, collection_path, item_name)
+        if scope == "attachment":
+            id = _secret_json['id']
+            return get_attachment(self.logger, id, field)
         if scope == "login":
             return parse_login_scope(_secret_json, field)
         if scope == "fields":


### PR DESCRIPTION
My second attempt to merge this feature.. 1 year after :) 

Allows getting Bitwarden secrets using the name of the Bitwarden Secret and its location (in a collection) instead of an ID.

Also, reduce duplication of code and improve some logic.