### PR TITLE
fix: add auth self-healing after repeated unlock failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ The operator can be configured using environment variables, either directly in `
 | `BW_CLIENTSECRET` | OAuth client secret (optional) | - | No |
 | `BW_SYNC_INTERVAL` | How often to sync with Bitwarden (seconds) | `900` (15 min) | No |
 | `BW_RELOGIN_INTERVAL` | How long to keep session unlocked / re-login interval (seconds) | `3600` (1 hour) | No |
+| `BW_AUTH_FAILURE_THRESHOLD` | Consecutive auth failures before forcing logout/cache reset and relogin | `3` | No |
 | `BW_FORCE_SYNC` | Force sync before every secret retrieval | `false` | No |
 | `DEBUG` | Enable debug logging | - | No |
 
@@ -464,6 +465,7 @@ The operator relies on the Bitwarden CLI for session handling:
 
 - The CLI may keep sessions unlocked for a configured interval (`BW_RELOGIN_INTERVAL`)
 - The operator assumes the CLI handles authentication state; adjust `BW_RELOGIN_INTERVAL` or credentials as needed
+- Repeated login/unlock failures can trigger automatic auth recovery based on `BW_AUTH_FAILURE_THRESHOLD`
 - No manual re-login should be required when the CLI session is valid
 
 ### Example Configuration
@@ -482,6 +484,8 @@ env:
     value: "600"  # Sync every 10 minutes
   - name: BW_RELOGIN_INTERVAL
     value: "7200"  # Keep session or re-login interval for 2 hours
+  - name: BW_AUTH_FAILURE_THRESHOLD
+    value: "3"  # Attempt auth recovery after 3 consecutive failures
   - name: DEBUG
     value: "true"  # Enable debug logging
 ```

--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -4,9 +4,9 @@ description: Deploy the Bitwarden CRD Operator
 
 type: application
 
-version: "v0.17.1"
+version: "v0.18.0"
 
-appVersion: "0.16.1"
+appVersion: "0.17.0"
 
 keywords:
   - operator
@@ -124,6 +124,8 @@ annotations:
       description: "Updated kopf to 1.44.4"
     - kind: changed
       description: "Updated kubernetes to 35.0.0"
+    - kind: changed
+      description: "Added self heal mechanism on vault unlock issues"
   artifacthub.io/images: |
     - name: bitwarden-crd-operator
-      image: ghcr.io/lerentis/bitwarden-crd-operator:0.16.1
+      image: ghcr.io/lerentis/bitwarden-crd-operator:0.17.0

--- a/charts/bitwarden-crd-operator/Chart.yaml
+++ b/charts/bitwarden-crd-operator/Chart.yaml
@@ -112,19 +112,7 @@ annotations:
   artifacthub.io/operator: "true"
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed critical bug where scheduled relogin failures caused operator to permanently stop syncing secrets until pod restart (issue #127)"
-    - kind: changed
-      description: "Updated Alpine base image to 3.23.3"
-    - kind: changed
-      description: "Updated Node.js to 24.14.1-r0"
-    - kind: changed
-      description: "Updated libcrypto3 to 3.5.5-r0"
-    - kind: changed
-      description: "Updated kopf to 1.44.4"
-    - kind: changed
-      description: "Updated kubernetes to 35.0.0"
-    - kind: changed
+    - kind: added
       description: "Added self heal mechanism on vault unlock issues"
   artifacthub.io/images: |
     - name: bitwarden-crd-operator

--- a/charts/bitwarden-crd-operator/README.md
+++ b/charts/bitwarden-crd-operator/README.md
@@ -27,6 +27,9 @@ env:
     value: "YoUrCliEntSecRet"
   - name: BW_PASSWORD
     value: "YourSuperSecurePassword"
+  # Optional: recover after repeated auth failures
+  - name: BW_AUTH_FAILURE_THRESHOLD
+    value: "3"
 ```
 
 you can also create a secret manually with these information and reference the existing secret like this in the `values.yaml`:

--- a/charts/bitwarden-crd-operator/values.yaml
+++ b/charts/bitwarden-crd-operator/values.yaml
@@ -31,6 +31,8 @@ deploymentStrategy: "Recreate"
 #     value: "define_id"
 ##  - name: BW_RELOGIN_INTERVAL
 ##    value: "3600"
+##  - name: BW_AUTH_FAILURE_THRESHOLD
+##    value: "3"
 
 externalConfigSecret:
   enabled: false

--- a/src/bitwardenCrdOperator.py
+++ b/src/bitwardenCrdOperator.py
@@ -5,14 +5,21 @@ import schedule
 import time
 import threading
 
-from utils.utils import command_wrapper, unlock_bw, sync_bw
+from utils.utils import BitwardenCommandException, command_wrapper, unlock_bw, sync_bw
 
-def bitwarden_signin(logger, **kwargs):
-    if 'BW_HOST' in os.environ:
+
+AUTH_FAILURE_THRESHOLD = 3
+auth_failures = 0
+
+
+def _configure_bw_host(logger):
+    if "BW_HOST" in os.environ:
         try:
             home_dir = os.path.expanduser("~")
             bw_host_file = os.path.join(home_dir, ".bw_host")
-            bw_host_env = os.getenv('BW_HOST')
+            bw_host_env = os.getenv("BW_HOST")
+            if bw_host_env is None:
+                return
             if os.path.isfile(bw_host_file):
                 with open(bw_host_file, "r") as f:
                     saved_host = f.read().strip()
@@ -31,21 +38,86 @@ def bitwarden_signin(logger, **kwargs):
         except BaseException:
             logger.warn("Received non-zero exit code from server config")
             logger.warn("This is expected from startup")
-            pass
     else:
         logger.info("BW_HOST not set. Assuming SaaS installation")
+
+
+def _auth_failure_threshold(logger):
+    configured_threshold = os.environ.get(
+        "BW_AUTH_FAILURE_THRESHOLD", str(AUTH_FAILURE_THRESHOLD)
+    )
+    try:
+        threshold = int(configured_threshold)
+        if threshold < 1:
+            raise ValueError("BW_AUTH_FAILURE_THRESHOLD must be greater than 0")
+        return threshold
+    except ValueError:
+        logger.warn(
+            f"Invalid BW_AUTH_FAILURE_THRESHOLD '{configured_threshold}', using {AUTH_FAILURE_THRESHOLD}"
+        )
+        return AUTH_FAILURE_THRESHOLD
+
+
+def recover_auth_state(logger):
+    os.environ.pop("BW_SESSION", None)
+    command_wrapper(logger, "logout", use_success=False)
+
+    home_dir = os.path.expanduser("~")
+    cli_data_file = os.path.join(home_dir, ".config", "Bitwarden CLI", "data.json")
+    if os.path.isfile(cli_data_file):
+        try:
+            os.remove(cli_data_file)
+            logger.warn("Removed Bitwarden CLI cache file to recover auth state")
+        except OSError as exc:
+            logger.warn(f"Could not remove Bitwarden CLI cache file: {exc}")
+
+
+def _login_and_unlock(logger):
     login_result = command_wrapper(logger, "login --apikey")
     if login_result is None:
-        logger.error("bw login failed, will retry on next schedule")
-        return
+        raise BitwardenCommandException("bw login failed")
     unlock_bw(logger)
+
+
+def bitwarden_signin(logger, **kwargs):
+    global auth_failures
+
+    _configure_bw_host(logger)
+    failure_threshold = _auth_failure_threshold(logger)
+
+    try:
+        _login_and_unlock(logger)
+        if auth_failures > 0:
+            logger.info("Authentication recovered")
+        auth_failures = 0
+        return
+    except BitwardenCommandException as exc:
+        auth_failures += 1
+        logger.error(
+            f"Authentication failed ({auth_failures}/{failure_threshold}): {exc}"
+        )
+
+    if auth_failures < failure_threshold:
+        return
+
+    logger.warn(
+        "Authentication failure threshold reached, recovering Bitwarden auth state"
+    )
+    recover_auth_state(logger)
+
+    try:
+        _login_and_unlock(logger)
+        auth_failures = 0
+        logger.info("Authentication recovery succeeded")
+    except BitwardenCommandException as exc:
+        logger.error(f"Authentication recovery failed: {exc}")
+
 
 def run_continuously(interval=30):
     cease_continuous_run = threading.Event()
 
     class ScheduleThread(threading.Thread):
-        @classmethod
-        def run(cls):
+        def run(self):
             while not cease_continuous_run.is_set():
                 schedule.run_pending()
                 time.sleep(interval)
@@ -54,12 +126,14 @@ def run_continuously(interval=30):
     continuous_thread.start()
     return cease_continuous_run
 
+
 def safe_bitwarden_signin(logger, **kwargs):
     """Wrapper for bitwarden_signin that prevents schedule job cancellation on errors."""
     try:
         bitwarden_signin(logger, **kwargs)
     except Exception as e:
         logger.error(f"Relogin failed: {e}. Will retry on next schedule.")
+
 
 def safe_sync_bw(logger, **kwargs):
     """Wrapper for sync_bw that prevents schedule job cancellation on errors."""
@@ -68,13 +142,14 @@ def safe_sync_bw(logger, **kwargs):
     except Exception as e:
         logger.error(f"Sync failed: {e}. Will retry on next schedule.")
 
+
 @kopf.on.startup()
 def load_schedules(logger, **kwargs):
     logger.info("Loading schedules")
     bitwarden_signin(logger)
 
-    bw_sync_interval = float(os.environ.get('BW_SYNC_INTERVAL', 900))
-    bw_relogin_interval = float(os.environ.get('BW_RELOGIN_INTERVAL', 3600))
+    bw_sync_interval = float(os.environ.get("BW_SYNC_INTERVAL", 900))
+    bw_relogin_interval = float(os.environ.get("BW_RELOGIN_INTERVAL", 3600))
 
     schedule.every(bw_relogin_interval).seconds.do(safe_bitwarden_signin, logger=logger)
     schedule.every(bw_sync_interval).seconds.do(safe_sync_bw, logger=logger)

--- a/src/bitwardenCrdOperator.py
+++ b/src/bitwardenCrdOperator.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 import os
+import sys
 import kopf
 import schedule
 import time
 import threading
 
-from utils.utils import BitwardenCommandException, command_wrapper, unlock_bw, sync_bw
+from utils.utils import command_wrapper, sync_bw
 
 
 AUTH_FAILURE_THRESHOLD = 3
@@ -46,16 +47,44 @@ def _auth_failure_threshold(logger):
     configured_threshold = os.environ.get(
         "BW_AUTH_FAILURE_THRESHOLD", str(AUTH_FAILURE_THRESHOLD)
     )
-    try:
-        threshold = int(configured_threshold)
-        if threshold < 1:
-            raise ValueError("BW_AUTH_FAILURE_THRESHOLD must be greater than 0")
-        return threshold
-    except ValueError:
-        logger.warn(
-            f"Invalid BW_AUTH_FAILURE_THRESHOLD '{configured_threshold}', using {AUTH_FAILURE_THRESHOLD}"
-        )
-        return AUTH_FAILURE_THRESHOLD
+    normalized_threshold = configured_threshold.strip()
+    if normalized_threshold.isdecimal():
+        threshold = int(normalized_threshold)
+        if threshold > 0:
+            return threshold
+
+    logger.warn(
+        f"Invalid BW_AUTH_FAILURE_THRESHOLD '{configured_threshold}', using {AUTH_FAILURE_THRESHOLD}"
+    )
+    return AUTH_FAILURE_THRESHOLD
+
+
+def _login_and_unlock(logger):
+    login_result = command_wrapper(logger, "login --apikey")
+    if login_result is None:
+        return False, "bw login failed"
+
+    status_output = command_wrapper(logger, "status", False)
+    if status_output is None or not isinstance(status_output, dict):
+        return False, "Failed to get bw status"
+
+    status = status_output.get("data", {}).get("template", {}).get("status")
+    if status == "unlocked":
+        if "DEBUG" in dict(os.environ):
+            logger.info("Already unlocked")
+        return True, ""
+
+    token_output = command_wrapper(logger, "unlock --passwordenv BW_PASSWORD")
+    if token_output is None or not isinstance(token_output, dict):
+        return False, "Failed to unlock vault"
+
+    token = token_output.get("data", {}).get("raw")
+    if token is None:
+        return False, "Failed to read session token"
+
+    os.environ["BW_SESSION"] = token
+    logger.info("Signin successful. Session exported")
+    return True, ""
 
 
 def recover_auth_state(logger):
@@ -72,30 +101,23 @@ def recover_auth_state(logger):
             logger.warn(f"Could not remove Bitwarden CLI cache file: {exc}")
 
 
-def _login_and_unlock(logger):
-    login_result = command_wrapper(logger, "login --apikey")
-    if login_result is None:
-        raise BitwardenCommandException("bw login failed")
-    unlock_bw(logger)
-
-
 def bitwarden_signin(logger, **kwargs):
     global auth_failures
 
     _configure_bw_host(logger)
     failure_threshold = _auth_failure_threshold(logger)
 
-    try:
-        _login_and_unlock(logger)
+    signin_ok, signin_error = _login_and_unlock(logger)
+    if signin_ok:
         if auth_failures > 0:
             logger.info("Authentication recovered")
         auth_failures = 0
         return
-    except BitwardenCommandException as exc:
-        auth_failures += 1
-        logger.error(
-            f"Authentication failed ({auth_failures}/{failure_threshold}): {exc}"
-        )
+
+    auth_failures += 1
+    logger.error(
+        f"Authentication failed ({auth_failures}/{failure_threshold}): {signin_error}"
+    )
 
     if auth_failures < failure_threshold:
         return
@@ -105,18 +127,22 @@ def bitwarden_signin(logger, **kwargs):
     )
     recover_auth_state(logger)
 
-    try:
-        _login_and_unlock(logger)
+    recovery_ok, recovery_error = _login_and_unlock(logger)
+    if recovery_ok:
         auth_failures = 0
         logger.info("Authentication recovery succeeded")
-    except BitwardenCommandException as exc:
-        logger.error(f"Authentication recovery failed: {exc}")
+        return
+
+    logger.error(f"Authentication recovery failed: {recovery_error}")
+    logger.error("Stopping operator process after failed authentication recovery")
+    sys.exit(1)
 
 
 def run_continuously(interval=30):
     cease_continuous_run = threading.Event()
 
     class ScheduleThread(threading.Thread):
+        @classmethod
         def run(self):
             while not cease_continuous_run.is_set():
                 schedule.run_pending()

--- a/tests/test_bitwarden_signin_recovery.py
+++ b/tests/test_bitwarden_signin_recovery.py
@@ -11,7 +11,6 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 import bitwardenCrdOperator as operator  # noqa: E402
-from utils.utils import BitwardenCommandException  # noqa: E402
 
 
 class DummyLogger:
@@ -42,24 +41,22 @@ class BitwardenSigninRecoveryTests(unittest.TestCase):
         os.environ.pop("BW_AUTH_FAILURE_THRESHOLD", None)
         os.environ.pop("BW_SESSION", None)
 
-    @patch("bitwardenCrdOperator.unlock_bw")
     @patch("bitwardenCrdOperator.command_wrapper")
-    def test_signin_success_resets_failure_counter(
-        self, command_wrapper_mock, unlock_bw_mock
-    ):
+    def test_signin_success_resets_failure_counter(self, command_wrapper_mock):
         operator.auth_failures = 2
-        command_wrapper_mock.return_value = {"success": True}
+        command_wrapper_mock.side_effect = [
+            {"success": True},
+            {"data": {"template": {"status": "unlocked"}}},
+        ]
 
         operator.bitwarden_signin(self.logger)
 
         self.assertEqual(operator.auth_failures, 0)
-        unlock_bw_mock.assert_called_once_with(self.logger)
 
     @patch("bitwardenCrdOperator.recover_auth_state")
-    @patch("bitwardenCrdOperator.unlock_bw")
     @patch("bitwardenCrdOperator.command_wrapper")
     def test_signin_failure_below_threshold_does_not_trigger_recovery(
-        self, command_wrapper_mock, unlock_bw_mock, recover_auth_state_mock
+        self, command_wrapper_mock, recover_auth_state_mock
     ):
         os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "3"
         command_wrapper_mock.return_value = None
@@ -67,27 +64,48 @@ class BitwardenSigninRecoveryTests(unittest.TestCase):
         operator.bitwarden_signin(self.logger)
 
         self.assertEqual(operator.auth_failures, 1)
-        unlock_bw_mock.assert_not_called()
         recover_auth_state_mock.assert_not_called()
 
     @patch("bitwardenCrdOperator.recover_auth_state")
-    @patch("bitwardenCrdOperator.unlock_bw")
     @patch("bitwardenCrdOperator.command_wrapper")
     def test_recovery_runs_after_threshold_and_resets_counter(
-        self, command_wrapper_mock, unlock_bw_mock, recover_auth_state_mock
+        self, command_wrapper_mock, recover_auth_state_mock
     ):
         os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "2"
         operator.auth_failures = 1
         command_wrapper_mock.side_effect = [
             None,
             {"success": True},
+            {"data": {"template": {"status": "locked"}}},
+            {"data": {"raw": "new-session"}},
         ]
 
         operator.bitwarden_signin(self.logger)
 
         recover_auth_state_mock.assert_called_once_with(self.logger)
         self.assertEqual(operator.auth_failures, 0)
-        self.assertEqual(unlock_bw_mock.call_count, 1)
+        self.assertEqual(os.environ.get("BW_SESSION"), "new-session")
+
+    @patch("bitwardenCrdOperator.sys.exit")
+    @patch("bitwardenCrdOperator.recover_auth_state")
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_recovery_failure_exits_process(
+        self, command_wrapper_mock, recover_auth_state_mock, sys_exit_mock
+    ):
+        os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "1"
+        command_wrapper_mock.side_effect = [None, None]
+
+        operator.bitwarden_signin(self.logger)
+
+        recover_auth_state_mock.assert_called_once_with(self.logger)
+        sys_exit_mock.assert_called_once_with(1)
+
+    def test_invalid_threshold_uses_default_without_exception_control_flow(self):
+        os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "invalid"
+
+        threshold = operator._auth_failure_threshold(self.logger)
+
+        self.assertEqual(threshold, operator.AUTH_FAILURE_THRESHOLD)
 
     @patch("bitwardenCrdOperator.command_wrapper")
     def test_recover_auth_state_clears_session_and_cache_file(
@@ -110,14 +128,13 @@ class BitwardenSigninRecoveryTests(unittest.TestCase):
                 self.logger, "logout", use_success=False
             )
 
-    @patch(
-        "bitwardenCrdOperator.unlock_bw",
-        side_effect=BitwardenCommandException("unlock failed"),
-    )
-    @patch("bitwardenCrdOperator.command_wrapper", return_value={"success": True})
-    def test_unlock_error_counts_as_auth_failure(
-        self, _command_wrapper_mock, _unlock_bw_mock
-    ):
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_status_failure_counts_as_auth_failure(self, command_wrapper_mock):
+        command_wrapper_mock.side_effect = [
+            {"success": True},
+            None,
+        ]
+
         operator.bitwarden_signin(self.logger)
 
         self.assertEqual(operator.auth_failures, 1)

--- a/tests/test_bitwarden_signin_recovery.py
+++ b/tests/test_bitwarden_signin_recovery.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import bitwardenCrdOperator as operator  # noqa: E402
+from utils.utils import BitwardenCommandException  # noqa: E402
+
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(("info", str(message)))
+
+    def warn(self, message):
+        self.messages.append(("warn", str(message)))
+
+    def error(self, message):
+        self.messages.append(("error", str(message)))
+
+
+class BitwardenSigninRecoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.logger = DummyLogger()
+        self.original_auth_failures = operator.auth_failures
+        operator.auth_failures = 0
+        os.environ.pop("BW_HOST", None)
+        os.environ.pop("BW_SESSION", None)
+        os.environ.pop("BW_AUTH_FAILURE_THRESHOLD", None)
+
+    def tearDown(self):
+        operator.auth_failures = self.original_auth_failures
+        os.environ.pop("BW_AUTH_FAILURE_THRESHOLD", None)
+        os.environ.pop("BW_SESSION", None)
+
+    @patch("bitwardenCrdOperator.unlock_bw")
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_signin_success_resets_failure_counter(
+        self, command_wrapper_mock, unlock_bw_mock
+    ):
+        operator.auth_failures = 2
+        command_wrapper_mock.return_value = {"success": True}
+
+        operator.bitwarden_signin(self.logger)
+
+        self.assertEqual(operator.auth_failures, 0)
+        unlock_bw_mock.assert_called_once_with(self.logger)
+
+    @patch("bitwardenCrdOperator.recover_auth_state")
+    @patch("bitwardenCrdOperator.unlock_bw")
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_signin_failure_below_threshold_does_not_trigger_recovery(
+        self, command_wrapper_mock, unlock_bw_mock, recover_auth_state_mock
+    ):
+        os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "3"
+        command_wrapper_mock.return_value = None
+
+        operator.bitwarden_signin(self.logger)
+
+        self.assertEqual(operator.auth_failures, 1)
+        unlock_bw_mock.assert_not_called()
+        recover_auth_state_mock.assert_not_called()
+
+    @patch("bitwardenCrdOperator.recover_auth_state")
+    @patch("bitwardenCrdOperator.unlock_bw")
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_recovery_runs_after_threshold_and_resets_counter(
+        self, command_wrapper_mock, unlock_bw_mock, recover_auth_state_mock
+    ):
+        os.environ["BW_AUTH_FAILURE_THRESHOLD"] = "2"
+        operator.auth_failures = 1
+        command_wrapper_mock.side_effect = [
+            None,
+            {"success": True},
+        ]
+
+        operator.bitwarden_signin(self.logger)
+
+        recover_auth_state_mock.assert_called_once_with(self.logger)
+        self.assertEqual(operator.auth_failures, 0)
+        self.assertEqual(unlock_bw_mock.call_count, 1)
+
+    @patch("bitwardenCrdOperator.command_wrapper")
+    def test_recover_auth_state_clears_session_and_cache_file(
+        self, command_wrapper_mock
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_file = Path(temp_dir) / ".config" / "Bitwarden CLI" / "data.json"
+            data_file.parent.mkdir(parents=True, exist_ok=True)
+            data_file.write_text("{ invalid", encoding="utf-8")
+            os.environ["BW_SESSION"] = "stale-session"
+
+            with patch(
+                "bitwardenCrdOperator.os.path.expanduser", return_value=temp_dir
+            ):
+                operator.recover_auth_state(self.logger)
+
+            self.assertNotIn("BW_SESSION", os.environ)
+            self.assertFalse(data_file.exists())
+            command_wrapper_mock.assert_called_once_with(
+                self.logger, "logout", use_success=False
+            )
+
+    @patch(
+        "bitwardenCrdOperator.unlock_bw",
+        side_effect=BitwardenCommandException("unlock failed"),
+    )
+    @patch("bitwardenCrdOperator.command_wrapper", return_value={"success": True})
+    def test_unlock_error_counts_as_auth_failure(
+        self, _command_wrapper_mock, _unlock_bw_mock
+    ):
+        operator.bitwarden_signin(self.logger)
+
+        self.assertEqual(operator.auth_failures, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds bounded auth self-healing to the Bitwarden CRD operator and documents the new tuning option in Helm/root docs.

## Problem

In some environments, the operator can enter a persistent auth failure loop:

- `You are not logged in.`
- `Failed to unlock vault`
- repeated `update_managed_secret` failures
  When this happens, periodic retries continue but may not recover without a manual pod restart.

## What changed

### Auth recovery logic

- Added consecutive auth failure tracking in `bitwarden_signin`.
- Added configurable threshold via env var:
  - `BW_AUTH_FAILURE_THRESHOLD` (default: `3`)
- When threshold is reached, operator now performs recovery:
  1. clears `BW_SESSION`
  2. runs `bw logout` (best effort)
  3. removes local Bitwarden CLI cache file `~/.config/Bitwarden CLI/data.json`
  4. retries login + unlock
- Counter resets after successful authentication.

### Documentation and chart values

- Added `BW_AUTH_FAILURE_THRESHOLD` to:
  - root README environment variable table + example
  - chart README example
  - chart `values.yaml` env snippet comments

## Why this approach

- Avoids brittle stderr-string matching for one specific error message.
- Uses deterministic recovery based on repeated auth/unlock failures.
- Improves resilience across multiple poisoned-state scenarios (stale session, broken local CLI state, etc.).

## Files changed

- `src/bitwardenCrdOperator.py`
- `tests/test_bitwarden_signin_recovery.py`
- `README.md`
- `charts/bitwarden-crd-operator/values.yaml`
- `charts/bitwarden-crd-operator/README.md`

## Tests

Added unit tests for:

- success resets failure counter
- below-threshold failures do not trigger recovery
- threshold-triggered recovery path
- recovery clears session + cache file
- unlock failures count toward auth failures
  Local verification run:

```bash
ruff check src/bitwardenCrdOperator.py tests/test_bitwarden_signin_recovery.py
python -m unittest discover -s tests
python -m compileall src
```
